### PR TITLE
Adaptar posición del filtro rápido

### DIFF
--- a/modules/FilterThreads.js
+++ b/modules/FilterThreads.js
@@ -86,7 +86,7 @@ function FilterThreads() {
 	/* Funcionalidad de ocultar hilos ya leídos */
 	function createHideReadThreadsButton() {
 	    hideReadThreads = helper.getValue("HIDDEN_READ_THREADS", false);
-	    var forumToolsButton = $("#forumtools");
+	    var forumToolsButton = $("#stickies_collapse");
 	    var hideReadThreadsLink = $('<a rel="nofollow">' + (hideReadThreads ? "Mostrar todos los hilos" : "Mostrar solo los hilos no leídos") + '</a>');
 	    hideReadThreadsButton = $('<td class="vbmenu_control" nowrap="nowrap" style="cursor: pointer;"></td>');
 	    hideReadThreadsButton.append(hideReadThreadsLink);


### PR DESCRIPTION
Coloca de nuevo en primera posición en la barra de navegación izquierda
para que el filtro rápido quede delante del interruptor para
mostrar/ocultar chinchetas.
