### PR TITLE
HighlightOP: Ajuste alineación de posts resaltados

### DIFF
--- a/modules/HighlightOP.js
+++ b/modules/HighlightOP.js
@@ -79,8 +79,8 @@ function HighlightOP() {
         }
         
         // Add CSS rules
-        GM_addStyle(".op_post, .op_quote { border-left: 10px solid " + helper.getValue("HIGHLIGHT_OP_COLOR", "#DC143C") + " !important; } .op_post td.alt2 { width: 167px; }");
-        GM_addStyle(".my_post, .my_quote { border-left: 10px solid " + helper.getValue("HIGHLIGHT_MY_POSTS_COLOR", "#1E90FF") + " !important; } .op_post td.alt2 { width: 167px; }");
+        GM_addStyle(".op_post, .op_quote { border-left: 10px solid " + helper.getValue("HIGHLIGHT_OP_COLOR", "#DC143C") + " !important; } .op_post td.alt2 { width: 166px; }");
+        GM_addStyle(".my_post, .my_quote { border-left: 10px solid " + helper.getValue("HIGHLIGHT_MY_POSTS_COLOR", "#1E90FF") + " !important; } .my_post td.alt2 { width: 166px; }");
         
         // Highlighted posts have "op_post" class
         for (var i = 0, n = users.length; i < n; i++) {


### PR DESCRIPTION
http://img.imgur.com/7cP2olY.png

Los posts del OP ya estaban correctamente alineados, sin embargo los propios posts no (había un error en el CSS).
