### PR TITLE
modulo AutoSpoiler

### DIFF
--- a/modules/AutoSpoiler.js
+++ b/modules/AutoSpoiler.js
@@ -30,10 +30,9 @@
     /*Buscamos los post con etiquetas quote y modificamos */
     SHURSCRIPT.eventbus.on('parsePost', parsePost);
     /* Añadimos el botón */
-    SHURSCRIPT.eventbus.on('editorReady', function () {
-      alert('');
+    //SHURSCRIPT.eventbus.on('editorReady', function () {
       addSpoilerButton();
-    });
+    //});
   };
 
   /* Pasamos el contenido del post a hideSpoiler */


### PR DESCRIPTION
Añado el módulo AutoSpoiler que se encarga de detectar cuando hay algún texto entre etiquetas [spoiler][/spoiler] o [SPOILER][/SPOILER]. En caso de haber texto lo sustituye por un botón para desplegar el spoiler.
